### PR TITLE
商品編集の直リンク禁止

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,6 +43,9 @@ before_action :set_item, only: [:show, :edit, :update, :destroy, :done, :purchas
 
   def edit
     @item = Item.find(params[:id])
+    if current_user.id != @item.user_id
+      redirect_to root_path
+    end
     grandchild_category = @item.category
     child_category = grandchild_category.parent
 


### PR DESCRIPTION
# What 
商品編集の直リンク禁止の実装。

#Why
他者が直接リンクを記述して、出品者の商品を編集することを防止するため。